### PR TITLE
Add a Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+Makefile
+README.md
+docs/
+test/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:2.7
+
+ADD . /app
+WORKDIR /app
+RUN python ./setup.py install
+
+CMD ["bladerunner"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:2.7
 
+RUN pip install pexpect futures==2.1.3
+
 ADD . /app
 WORKDIR /app
 RUN python ./setup.py build

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM python:2.7
 
 ADD . /app
 WORKDIR /app
+RUN python ./setup.py build
 RUN python ./setup.py install
 
 CMD ["bladerunner"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+build:
+    @docker build -t demonware/bladerunner:latest .
+
+push:
+    @docker push demonware/bladerunner:latest

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
+DOCKER_TAG ?= latest
+
+default: build push
+
 build:
-    @docker build -t demonware/bladerunner:latest .
+	echo "Building Docker Image for $DOCKER_TAG"
+	docker build -t demonware/bladerunner:$(DOCKER_TAG) .
 
 push:
-    @docker push demonware/bladerunner:latest
+	docker push demonware/bladerunner:$(DOCKER_TAG)


### PR DESCRIPTION
This PR adds a `Dockerfile` which allows us to build a nice, self-contained, Docker image for Bladerunner. This primarily acts as an entrypoint for Windows users who may otherwise encounter issues running Bladerunner on their machines.

Ping me if you've got any questions/suggestions about this on bpannell@demonware.net
